### PR TITLE
fix: reusable breaking news component to every page inside the template

### DIFF
--- a/public/static/assets/css/styles.css
+++ b/public/static/assets/css/styles.css
@@ -150,7 +150,11 @@ nav {
 
 .breaking-news-logo {
     background-color: #000000;
-    padding: 10px 15px;
+    padding: 0 15px;
+    height: 40px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     clip-path: polygon(0 0, 100% 0, 93% 100%, 0% 100%);
     position: absolute;
     border-bottom-left-radius: 10px;
@@ -169,7 +173,9 @@ nav {
     z-index: -1;
     position: relative;
     background-color: #ca0000;
-    padding: 10px 15px;
+    padding: 0 15px;
+    height: 40px;
+    line-height: 40px;
     border-bottom-left-radius: 10px;
     border-bottom-right-radius: 10px;
 }

--- a/resources/views/defaultsite/desktop/components-ui/ui-breaking-news.blade.php
+++ b/resources/views/defaultsite/desktop/components-ui/ui-breaking-news.blade.php
@@ -1,12 +1,16 @@
-<div class="breaking-news-container">
-    <div class="breaking-news-logo">
-        <span>breaking news</span>
-    </div>
-    <div class="breaking-text-marquee">
-        <span>
-            <marquee direction="left">
-                {{ $bn[0]['news_title'] }}
-            </marquee>
-        </span>
-    </div>
-</div>
+@if ($breaking = \Data::headline() ?? null)
+    @if (count($breaking) > 0)
+        <div class="breaking-news-container">
+            <div class="breaking-news-logo">
+                <span>breaking news</span>
+            </div>
+            <div class="breaking-text-marquee">
+                <span>
+                    <marquee direction="left">
+                        {{ $breaking[0]['news_title'] }}
+                    </marquee>
+                </span>
+            </div>
+        </div>
+    @endif
+@endif

--- a/resources/views/defaultsite/desktop/layouts/ui-main.blade.php
+++ b/resources/views/defaultsite/desktop/layouts/ui-main.blade.php
@@ -104,9 +104,7 @@
         @include('defaultsite.desktop.components-ui.ui-header')
 
         {{-- Breaking news --}}
-        @if ($headline[0]['news_id'] ?? null)
-            @include('defaultsite.desktop.components-ui.ui-breaking-news', ['bn' => $headline])
-        @endif
+        @include('defaultsite.desktop.components-ui.ui-breaking-news')
 
         {{-- Content --}}
         @yield('content')


### PR DESCRIPTION
fixing reusable breaking news component to every page inside the template